### PR TITLE
implement custom fields on connection types

### DIFF
--- a/lib/graphql/relay/base_connection.rb
+++ b/lib/graphql/relay/base_connection.rb
@@ -18,13 +18,14 @@ module GraphQL
       CONNECTION_IMPLEMENTATIONS = {}
 
       # Create a connection which exposes edges of this type
-      def self.create_type(wrapped_type)
+      def self.create_type(wrapped_type, &block)
         edge_type = Edge.create_type(wrapped_type)
 
         connection_type = ObjectType.define do
           name("#{wrapped_type.name}Connection")
           field :edges, types[edge_type]
           field :pageInfo, PageInfo, property: :page_info
+          block && instance_eval(&block)
         end
 
         connection_type

--- a/spec/graphql/relay/relation_connection_spec.rb
+++ b/spec/graphql/relay/relation_connection_spec.rb
@@ -28,6 +28,7 @@ describe GraphQL::Relay::RelationConnection do
       }
 
       fragment basesConnection on BaseConnection {
+        totalCount,
         edges {
           cursor
           node {
@@ -36,6 +37,7 @@ describe GraphQL::Relay::RelationConnection do
         }
       }
     |}
+
     it 'limits the result' do
       result = query(query_string, "first" => 2)
       assert_equal(2, get_names(result).length)
@@ -50,6 +52,14 @@ describe GraphQL::Relay::RelationConnection do
 
       result = query(query_string, "first" => 100)
       assert_equal(false, get_page_info(result)["hasNextPage"])
+    end
+
+    it 'provides custom fileds on the connection type' do
+      result = query(query_string, "first" => 2)
+      assert_equal(
+        Base.where(faction_id: 2).count,
+        result["data"]["empire"]["bases"]["totalCount"]
+      )
     end
 
     it 'slices the result' do

--- a/spec/support/star_wars_schema.rb
+++ b/spec/support/star_wars_schema.rb
@@ -31,6 +31,16 @@ BaseType = GraphQL::ObjectType.define do
   field :planet, types.String
 end
 
+# Define a connection which will wrap an ActiveRecord::Relation.
+# We use an optional block to add fields to the connection type:
+BaseConnection = GraphQL::Relay::RelationConnection.create_type(BaseType) do
+  field :totalCount do
+    type types.Int
+    resolve -> (obj, args, ctx) { obj.object.count }
+  end
+end
+
+
 Faction = GraphQL::ObjectType.define do
   name "Faction"
   interfaces [NodeInterface]
@@ -49,7 +59,7 @@ Faction = GraphQL::ObjectType.define do
     # You can define arguments here and use them in the connection
     argument :nameIncludes, types.String
   end
-  connection :bases, BaseType.connection_type do
+  connection :bases, BaseConnection do
     # Resolve field should return an Array, the Connection
     # will do the rest!
     resolve -> (obj, args, ctx) {


### PR DESCRIPTION
I am working on a ruby version of the backend for the relay todos example, and realized custom fields on connection types are required.  Tests pass here, but rebasing on your latest commit causes some spec failures - going to try to correct those now.