### PR TITLE
add query context as argument to node identification # object from id

### DIFF
--- a/lib/graphql/relay/global_node_identification.rb
+++ b/lib/graphql/relay/global_node_identification.rb
@@ -53,7 +53,7 @@ module GraphQL
           type(ident.interface)
           argument :id, !types.ID
           resolve -> (obj, args, ctx) {
-            ident.object_from_id(args[:id])
+            ident.object_from_id(args[:id], ctx)
           }
         end
       end
@@ -78,8 +78,8 @@ module GraphQL
 
       # Use the provided config to
       # get an object from a UUID
-      def object_from_id(id)
-        @object_from_id_proc.call(id)
+      def object_from_id(id, ctx)
+        @object_from_id_proc.call(id, ctx)
       end
     end
   end

--- a/spec/support/star_wars_schema.rb
+++ b/spec/support/star_wars_schema.rb
@@ -7,7 +7,7 @@
 # - an interface for Relay ObjectTypes to implement
 # See global_node_identification.rb for the full API.
 NodeIdentification = GraphQL::Relay::GlobalNodeIdentification.define do
-  object_from_id -> (id) do
+  object_from_id -> (id, ctx) do
     type_name, id = NodeIdentification.from_global_id(id)
     STAR_WARS_DATA[type_name][id]
   end


### PR DESCRIPTION
I ended up w/ a Session type which includes the current user as a field (so that user can be logged in and out using mutations), I needed the context here in order to build a Session object.

I am not 100% sure I have this set up in an ideal way - do you have any objections to including context as an argument here?