### PR TITLE
Relation compat with Rails 3.2

### DIFF
--- a/lib/graphql/relay/relation_connection.rb
+++ b/lib/graphql/relay/relation_connection.rb
@@ -29,7 +29,7 @@ module GraphQL
           items = object
 
           if order
-            items = items.order(order_name => order_direction)
+            items = items.order(items.table[order_name].public_send(order_direction))
           end
 
           if after


### PR DESCRIPTION
Btw, I recommend using the appraisal gem to test multiple rails versions.
Here's the Appraisals file I'm using locally:
```ruby
appraise 'rails_3.2' do
  gem 'activerecord', '~> 3.2.21'
end

appraise 'rails_4.0' do
  gem 'activerecord', '~> 4.0.13'
  gem 'minitest'
  gem 'minitest-reporters'
end

appraise 'rails_4.1' do
  gem 'activerecord', '~> 4.1.10'
end

appraise 'rails_4.2' do
  gem 'activerecord', '~> 4.2.4'
end
```