### PR TITLE
return_field argument should be a Type, confusing in example

### DIFF
--- a/lib/graphql/relay/mutation.rb
+++ b/lib/graphql/relay/mutation.rb
@@ -17,7 +17,7 @@ module GraphQL
     #     input_field :name, !types.String
     #     input_field :itemId, !types.ID
     #
-    #     return_field :item, Item
+    #     return_field :item, ItemType
     #
     #     resolve -> (inputs, ctx) {
     #       item = Item.find_by_id(inputs[:id])


### PR DESCRIPTION
I personally found that example confusing, `return_field` should return a `Type` and not the object class you're actually going to fetch in resolve.

Maybe that would be better ?