### PR TITLE
Remove usage of #reverse_merge.

### DIFF
--- a/lib/graphql/relay/base_connection.rb
+++ b/lib/graphql/relay/base_connection.rb
@@ -2,8 +2,8 @@ module GraphQL
   module Relay
     # Subclasses must implement:
     #   - {#cursor_from_node}, which returns an opaque cursor for the given item
-    #   - {#sliced_edges}, which slices by `before` & `after`
-    #   - {#paged_edges}, which applies `first` & `last` limits
+    #   - {#sliced_nodes}, which slices by `before` & `after`
+    #   - {#paged_nodes}, which applies `first` & `last` limits
     #
     # In a subclass, you have access to
     #   - {#object}, the object which the connection will wrap

--- a/lib/graphql/relay/connection_field.rb
+++ b/lib/graphql/relay/connection_field.rb
@@ -29,7 +29,7 @@ module GraphQL
       # @param [GraphQL::Field] A field which returns items to be wrapped as a connection
       # @return [GraphQL::Field] A field which serves a connections
       def self.create(underlying_field)
-        underlying_field.arguments = underlying_field.arguments.reverse_merge(DEFAULT_ARGUMENTS)
+        underlying_field.arguments = DEFAULT_ARGUMENTS.merge(underlying_field.arguments)
         # TODO: make a public API on GraphQL::Field to expose this proc
         original_resolve = underlying_field.instance_variable_get(:@resolve_proc)
         underlying_field.resolve = get_connection_resolve(underlying_field.name, original_resolve)


### PR DESCRIPTION
Looks like a usage of ActiveSupport's reverse_merge slipped into the library. The tests didn't catch it because ActiveRecord is a testing dependency - I ran into it because I'm using the gem with an app that doesn't use Rails.

Also noticed some out-of-date documentation, so I figured I'd throw it in too.