### PR TITLE
Fixed handling of to_global_id for UUID's

### DIFF
--- a/lib/graphql/relay/global_node_identification.rb
+++ b/lib/graphql/relay/global_node_identification.rb
@@ -6,8 +6,10 @@ module GraphQL
     # GlobalIdField depends on that, since it calls class methods
     # which delegate to the singleton instance.
     class GlobalNodeIdentification
-      # Just to encode data in the id, use something that won't conflict
-      ID_AND_TYPE_SEPARATOR = "---"
+      class << self
+	attr_accessor :id_separator
+      end
+      self.id_separator = "-"
 
       include GraphQL::DefinitionHelpers::DefinedByConfig
       defined_by_config :object_from_id_proc, :type_from_object_proc
@@ -57,16 +59,16 @@ module GraphQL
       # Create a global ID for type-name & ID
       # (This is an opaque transform)
       def to_global_id(type_name, id)
-        if type_name.include?(ID_AND_TYPE_SEPARATOR) || id.include?(ID_AND_TYPE_SEPARATOR)
-          raise "to_global_id(#{type_name}, #{id}) contains reserved characters `#{ID_AND_TYPE_SEPARATOR}`"
+        if type_name.include?(self.class.id_separator) || id.include?(self.class.id_separator)
+          raise "to_global_id(#{type_name}, #{id}) contains reserved characters `#{self.class.id_separator}`"
         end
-        Base64.strict_encode64([type_name, id].join(ID_AND_TYPE_SEPARATOR))
+        Base64.strict_encode64([type_name, id].join(self.class.id_separator))
       end
 
       # Get type-name & ID from global ID
       # (This reverts the opaque transform)
       def from_global_id(global_id)
-        Base64.decode64(global_id).split(ID_AND_TYPE_SEPARATOR)
+        Base64.decode64(global_id).split(self.class.id_separator)
       end
 
       # Use the provided config to

--- a/spec/graphql/relay/global_node_identification_spec.rb
+++ b/spec/graphql/relay/global_node_identification_spec.rb
@@ -22,7 +22,7 @@ describe GraphQL::Relay::GlobalNodeIdentification do
       }|)
       expected = {"data" => {
         "node"=>{
-          "id"=>"RmFjdGlvbi0tLTE=",
+          "id"=>"RmFjdGlvbi0x",
           "name"=>"Alliance to Restore the Republic",
           "ships"=>{
             "edges"=>[
@@ -38,6 +38,20 @@ describe GraphQL::Relay::GlobalNodeIdentification do
     end
   end
 
+  after do
+    # Set the id_separator back to it's default after each spec, since some of
+    # them change it at runtime
+    GraphQL::Relay::GlobalNodeIdentification.id_separator = "-"
+  end
+
+  describe 'id_separator' do
+    it "allows you to change it at runtime" do
+      GraphQL::Relay::GlobalNodeIdentification.id_separator = "-zomg-"
+
+      assert_equal("-zomg-", GraphQL::Relay::GlobalNodeIdentification.id_separator)
+    end
+  end
+
   describe 'to_global_id / from_global_id ' do
     it 'Converts typename and ID to and from ID' do
       global_id = node_identification.to_global_id("SomeType", "123")
@@ -46,7 +60,9 @@ describe GraphQL::Relay::GlobalNodeIdentification do
       assert_equal("123", id)
     end
 
-    it "handles ID's and Types with dashes in them" do
+    it "allows you to change the id_separator" do
+      GraphQL::Relay::GlobalNodeIdentification.id_separator = "---"
+
       global_id = node_identification.to_global_id("Type-With-UUID", "250cda0e-a89d-41cf-99e1-2872d89f1100")
       type_name, id = node_identification.from_global_id(global_id)
       assert_equal("Type-With-UUID", type_name)
@@ -55,9 +71,9 @@ describe GraphQL::Relay::GlobalNodeIdentification do
 
     it "raises an error if you try and use a reserved character in the ID" do
       err = assert_raises(RuntimeError) {
-        node_identification.to_global_id("Best---Thing", "234")
+        node_identification.to_global_id("Best-Thing", "234")
       }
-      assert_includes err.message, "to_global_id(Best---Thing, 234) contains reserved characters `---`"
+      assert_includes err.message, "to_global_id(Best-Thing, 234) contains reserved characters `-`"
     end
   end
 

--- a/spec/graphql/relay/global_node_identification_spec.rb
+++ b/spec/graphql/relay/global_node_identification_spec.rb
@@ -22,7 +22,7 @@ describe GraphQL::Relay::GlobalNodeIdentification do
       }|)
       expected = {"data" => {
         "node"=>{
-          "id"=>"RmFjdGlvbi0x",
+          "id"=>"RmFjdGlvbi0tLTE=",
           "name"=>"Alliance to Restore the Republic",
           "ships"=>{
             "edges"=>[
@@ -44,6 +44,20 @@ describe GraphQL::Relay::GlobalNodeIdentification do
       type_name, id = node_identification.from_global_id(global_id)
       assert_equal("SomeType", type_name)
       assert_equal("123", id)
+    end
+
+    it "handles ID's and Types with dashes in them" do
+      global_id = node_identification.to_global_id("Type-With-UUID", "250cda0e-a89d-41cf-99e1-2872d89f1100")
+      type_name, id = node_identification.from_global_id(global_id)
+      assert_equal("Type-With-UUID", type_name)
+      assert_equal("250cda0e-a89d-41cf-99e1-2872d89f1100", id)
+    end
+
+    it "raises an error if you try and use a reserved character in the ID" do
+      err = assert_raises(RuntimeError) {
+        node_identification.to_global_id("Best---Thing", "234")
+      }
+      assert_includes err.message, "to_global_id(Best---Thing, 234) contains reserved characters `---`"
     end
   end
 


### PR DESCRIPTION
This fix is to enable the use of true UUID's (like `11620412-843e-411a-92e7-da1b889f069a`) as values in the `to_global_id` method. Previous it used a basic `.split("-")` method, which broken on dashes.

I've used a similar method to how you encode the cursor, and added an error if the user uses the reserved `---` sequence.