### PR TITLE
Fix mutation docs

### DIFF
--- a/lib/graphql/relay/mutation.rb
+++ b/lib/graphql/relay/mutation.rb
@@ -28,7 +28,7 @@ module GraphQL
     #
     #   MutationType = GraphQL::ObjectType.define do
     #     # The mutation object exposes a field:
-    #     field :updateName, UpdateNameMutation.field
+    #     field :updateName, field: UpdateNameMutation.field
     #   end
     #
     #   # Then query it:


### PR DESCRIPTION
Just a quick fix because the usage example wasn't documented properly (missing a `field: `)