### PR TITLE
Support custom edge fields

### DIFF
--- a/lib/graphql/relay/base_connection.rb
+++ b/lib/graphql/relay/base_connection.rb
@@ -19,8 +19,8 @@ module GraphQL
       CONNECTION_IMPLEMENTATIONS = {}
 
       # Create a connection which exposes edges of this type
-      def self.create_type(wrapped_type, &block)
-        edge_type = wrapped_type.edge_type
+      def self.create_type(wrapped_type, edge_type: nil, &block)
+        edge_type = edge_type || wrapped_type.edge_type
 
         connection_type = ObjectType.define do
           name("#{wrapped_type.name}Connection")

--- a/lib/graphql/relay/edge.rb
+++ b/lib/graphql/relay/edge.rb
@@ -14,11 +14,12 @@ module GraphQL
         @cursor ||= @connection.cursor_from_node(node)
       end
 
-      def self.create_type(wrapped_type)
+      def self.create_type(wrapped_type, &block)
         GraphQL::ObjectType.define do
           name("#{wrapped_type.name}Edge")
           field :node, wrapped_type
           field :cursor, !types.String
+          block && instance_eval(&block)
         end
       end
     end

--- a/lib/graphql/relay/monkey_patches/base_type.rb
+++ b/lib/graphql/relay/monkey_patches/base_type.rb
@@ -1,16 +1,16 @@
 class GraphQL::BaseType
-  def connection_type
-    @connection_type ||= define_connection
+  def connection_type(edge_type: nil)
+    @connection_type ||= define_connection(edge_type: edge_type)
   end
 
   def edge_type
     @edge_type ||= GraphQL::Relay::Edge.create_type(self)
   end
 
-  def define_connection(&block)
+  def define_connection(edge_type: nil, &block)
     if !@connection_type.nil?
       raise("#{name}'s connection type was already defined, can't redefine it!")
     end
-    @connection_type = GraphQL::Relay::BaseConnection.create_type(self, &block)
+    @connection_type = GraphQL::Relay::BaseConnection.create_type(self, edge_type: edge_type, &block)
   end
 end

--- a/spec/graphql/relay/array_connection_spec.rb
+++ b/spec/graphql/relay/array_connection_spec.rb
@@ -15,6 +15,7 @@ describe GraphQL::Relay::ArrayConnection do
         rebels {
           ships(first: $first, after: $after, last: $last, before: $before, order: $order, nameIncludes: $nameIncludes) {
             edges {
+              since
               cursor
               node {
                 name
@@ -27,6 +28,11 @@ describe GraphQL::Relay::ArrayConnection do
         }
       }
     |}
+ 
+    it 'handles extra edge fields' do
+      result = query(query_string, "first" => 2)
+      assert_equal('forever', result["data"]["rebels"]["ships"]["edges"][0]["since"])
+    end
 
     it 'limits the result' do
       result = query(query_string, "first" => 2)

--- a/spec/support/star_wars_schema.rb
+++ b/spec/support/star_wars_schema.rb
@@ -46,13 +46,19 @@ BaseType.define_connection do
   end
 end
 
+ShipEdgeType = GraphQL::Relay::Edge.create_type(Ship) do
+  field :since do
+    type types.String
+    resolve -> (_, _, _) { 'forever' }
+  end
+end
 
 Faction = GraphQL::ObjectType.define do
   name "Faction"
   interfaces [NodeIdentification.interface]
   field :id, field: GraphQL::Relay::GlobalIdField.new("Faction")
   field :name, types.String
-  connection :ships, Ship.connection_type do
+  connection :ships, Ship.connection_type(edge_type: ShipEdgeType) do
     # Resolve field should return an Array, the Connection
     # will do the rest!
     resolve -> (obj, args, ctx) {


### PR DESCRIPTION
Support for adding custom fields to edges.

```
ShipEdgeType = GraphQL::Relay::Edge.create_type(Ship) do
  field :since do
    type types.String
    resolve -> (_, _, _) { 'forever' }
  end
end
```

```
connection :ships, Ship.connection_type(edge_type: ShipEdgeType) do
  # ...
end
```

Extends DSL to `Edge.create_type` so you can pass a config block, and allows connections to pass an `edge_type` arg to specify which edge type should be used.


I'll write some doc once we're sure about the implementation!
