### PR TITLE
refactor(Connections) remove the default :order argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,8 +198,6 @@ First, define the custom connection:
 ```ruby
 class SetConnection < BaseConnection
   # derive a cursor from `item`
-  # (it is used to find next & previous nodes,
-  # so it should include `order`)
   def cursor_from_node(item)
     # ...
   end

--- a/lib/graphql/relay/connection_field.rb
+++ b/lib/graphql/relay/connection_field.rb
@@ -12,7 +12,6 @@ module GraphQL
           [:after, GraphQL::STRING_TYPE],
           [:last, GraphQL::INT_TYPE],
           [:before, GraphQL::STRING_TYPE],
-          [:order, GraphQL::STRING_TYPE],
         ]
 
       DEFAULT_ARGUMENTS = ARGUMENT_DEFINITIONS.reduce({}) do |memo, arg_defn|
@@ -31,8 +30,7 @@ module GraphQL
       # @return [GraphQL::Field] A field which serves a connections
       def self.create(underlying_field, max_page_size: nil)
         underlying_field.arguments = DEFAULT_ARGUMENTS.merge(underlying_field.arguments)
-        # TODO: make a public API on GraphQL::Field to expose this proc
-        original_resolve = underlying_field.instance_variable_get(:@resolve_proc)
+        original_resolve = underlying_field.resolve_proc
         underlying_field.resolve = get_connection_resolve(underlying_field.name, original_resolve, max_page_size: max_page_size)
         underlying_field
       end

--- a/lib/graphql/relay/relation_connection.rb
+++ b/lib/graphql/relay/relation_connection.rb
@@ -1,16 +1,9 @@
 module GraphQL
   module Relay
     class RelationConnection < BaseConnection
-      DEFAULT_ORDER = "id"
-
       def cursor_from_node(item)
-        order_value = item.public_send(order_name)
-        cursor_parts = [order, order_value]
-        Base64.strict_encode64(cursor_parts.join(CURSOR_SEPARATOR))
-      end
-
-      def order
-        @order ||= (super || DEFAULT_ORDER)
+        offset = initial_offset + paged_nodes_array.index(item) + 1
+        Base64.strict_encode64(offset.to_s)
       end
 
       def has_next_page
@@ -26,11 +19,10 @@ module GraphQL
 
       # apply first / last limit results
       def paged_nodes
-        @paged_nodes = begin
+        @paged_nodes ||= begin
           items = sliced_nodes
           limit = [first, last, max_page_size].compact.min
-          first && items = items.first(limit)
-          last && items.count > last && items = items.last(limit)
+          items = items.limit(limit)
           items
         end
       end
@@ -39,61 +31,34 @@ module GraphQL
       def sliced_nodes
         @sliced_nodes ||= begin
           items = object
-
-          if order
-            items = items.order(items.table[order_name].public_send(order_direction))
-          end
-
-          if after
-            _o, order_value = slice_from_cursor(after)
-            direction_marker = order_direction == :asc ? ">" : "<"
-            where_condition = create_order_condition(table_name, order_name, order_value, direction_marker)
-            items = items.where(where_condition)
-          end
-
-          if before
-            _o, order_value = slice_from_cursor(before)
-            direction_marker = order_direction == :asc ? "<" : ">"
-            where_condition = create_order_condition(table_name, order_name, order_value, direction_marker)
-            items = items.where(where_condition)
-          end
-
+          items = items.offset(initial_offset)
           items
         end
       end
 
-      def slice_from_cursor(cursor)
-        decoded = Base64.decode64(cursor)
-        order, order_value = decoded.split(CURSOR_SEPARATOR)
+      def offset_from_cursor(cursor)
+        Base64.decode64(cursor).to_i
       end
 
-      # Remove possible direction marker:
-      def order_name
-        @order_name ||= order.sub(/^-/, '')
-      end
-
-      # Check for direction marker
-      def order_direction
-        @order_direction ||= order.start_with?("-") ? :desc : :asc
-      end
-
-      def table_name
-        @table_name ||= object.table.table_name
-      end
-
-      # When creating the where constraint, cast the value to correct column data type so
-      # active record can send it in correct format to db
-      def create_order_condition(table, column, value, direction_marker)
-        table_name = ActiveRecord::Base.connection.quote_table_name(table)
-        name = ActiveRecord::Base.connection.quote_column_name(column)
-        if ActiveRecord::VERSION::MAJOR == 5
-          casted_value = object.table.able_to_type_cast? ? object.table.type_cast_for_database(column, value) : value
-        elsif ActiveRecord::VERSION::MAJOR == 4 && ActiveRecord::VERSION::MINOR >= 2
-          casted_value = object.table.engine.columns_hash[column].cast_type.type_cast_from_user(value)
-        else
-          casted_value = object.table.engine.columns_hash[column].type_cast(value)
+      def initial_offset
+        @initial_offset ||= begin
+          if after
+            # The initial offset is in the last cursor
+            offset_from_cursor(after)
+          elsif before
+            # The initial offset
+            prev_offset = offset_from_cursor(before)
+            min_next_offset = prev_offset - last - 1
+            next_offset = [min_next_offset, 0].max
+            next_offset
+          else
+            0
+          end
         end
-        ["#{table_name}.#{name} #{direction_marker} ?", casted_value]
+      end
+
+      def paged_nodes_array
+        @paged_nodes_array ||= paged_nodes.to_a
       end
     end
 

--- a/spec/graphql/relay/array_connection_spec.rb
+++ b/spec/graphql/relay/array_connection_spec.rb
@@ -11,9 +11,9 @@ describe GraphQL::Relay::ArrayConnection do
   end
   describe "results" do
     let(:query_string) {%|
-      query getShips($first: Int, $after: String, $last: Int, $before: String, $order: String, $nameIncludes: String){
+      query getShips($first: Int, $after: String, $last: Int, $before: String, $nameIncludes: String){
         rebels {
-          ships(first: $first, after: $after, last: $last, before: $before, order: $order, nameIncludes: $nameIncludes) {
+          ships(first: $first, after: $after, last: $last, before: $before, nameIncludes: $nameIncludes) {
             edges {
               cursor
               node {
@@ -59,22 +59,6 @@ describe GraphQL::Relay::ArrayConnection do
 
       result = query(query_string, "before" => last_cursor, "last" => 2)
       assert_equal(["X-Wing", "Y-Wing"], get_names(result))
-    end
-
-    it 'paginates with order' do
-      result = query(query_string, "first" => 2, "order" => "name")
-      assert_equal(["A-Wing", "Home One"], get_names(result))
-
-      # After the last result, find the next 2:
-      last_cursor = result["data"]["rebels"]["ships"]["edges"].last["cursor"]
-
-      result = query(query_string, "after" => last_cursor, "first" => 2, "order" => "name")
-      assert_equal(["Millenium Falcon", "X-Wing"], get_names(result))
-    end
-
-    it 'paginates with reverse order' do
-      result = query(query_string, "first" => 2, "order" => "-name")
-      assert_equal(["Y-Wing", "X-Wing"], get_names(result))
     end
 
     it 'applies custom arguments' do

--- a/spec/graphql/relay/page_info_spec.rb
+++ b/spec/graphql/relay/page_info_spec.rb
@@ -15,9 +15,9 @@ describe GraphQL::Relay::PageInfo do
   }
 
   let(:query_string) {%|
-    query getShips($first: Int, $after: String, $last: Int, $before: String, $order: String, $nameIncludes: String){
+    query getShips($first: Int, $after: String, $last: Int, $before: String, $nameIncludes: String){
       empire {
-        bases(first: $first, after: $after, last: $last, before: $before, order: $order, nameIncludes: $nameIncludes) {
+        bases(first: $first, after: $after, last: $last, before: $before, nameIncludes: $nameIncludes) {
           edges {
             cursor
           }

--- a/spec/graphql/relay/relation_connection_spec.rb
+++ b/spec/graphql/relay/relation_connection_spec.rb
@@ -12,9 +12,9 @@ describe GraphQL::Relay::RelationConnection do
 
   describe "results" do
     let(:query_string) {%|
-      query getShips($first: Int, $after: String, $last: Int, $before: String, $order: String, $nameIncludes: String){
+      query getShips($first: Int, $after: String, $last: Int, $before: String,  $nameIncludes: String){
         empire {
-          bases(first: $first, after: $after, last: $last, before: $before, order: $order, nameIncludes: $nameIncludes) {
+          bases(first: $first, after: $after, last: $last, before: $before, nameIncludes: $nameIncludes) {
             ... basesConnection
           }
         }
@@ -63,22 +63,6 @@ describe GraphQL::Relay::RelationConnection do
 
       result = query(query_string, "before" => last_cursor, "last" => 2)
       assert_equal(["Death Star", "Shield Generator"], get_names(result))
-    end
-
-    it 'paginates with reverse order' do
-      result = query(query_string, "first" => 2, "order" => "-name")
-      assert_equal(["Shield Generator", "Headquarters"], get_names(result))
-    end
-
-    it 'paginates with order' do
-      result = query(query_string, "first" => 2, "order" => "name")
-      assert_equal(["Death Star", "Headquarters"], get_names(result))
-
-      # After the last result, find the next 2:
-      last_cursor = get_last_cursor(result)
-
-      result = query(query_string, "after" => last_cursor, "first" => 2, "order" => "name")
-      assert_equal(["Shield Generator"], get_names(result))
     end
 
     it "applies custom arguments" do
@@ -154,7 +138,7 @@ describe GraphQL::Relay::RelationConnection do
     end
   end
 
-  describe "overriding default order" do
+  describe "custom ordering" do
     let(:query_string) {%|
       query getBases {
         empire {

--- a/spec/support/star_wars_schema.rb
+++ b/spec/support/star_wars_schema.rb
@@ -87,6 +87,13 @@ Faction = GraphQL::ObjectType.define do
   connection :basesClone, BaseType.connection_type
   connection :basesByName, BaseType.connection_type, property: :bases do
     argument :order, types.String, default_value: "name"
+    resolve -> (obj, args, ctx) {
+      if args[:order].present?
+        obj.bases.order(args[:order])
+      else
+        obj.bases
+      end
+    }
   end
 
   connection :basesWithMaxLimitRelation, BaseType.connection_type, max_page_size: 2 do


### PR DESCRIPTION
Here's another try at #31 which just encodes `OFFSET` in the cursor. I _think_ this is enough to move through the records. I kept a test for adding a custom order argument and it looks good to me. Did I miss anything??