### PR TITLE
pass cursor directly to edge

### DIFF
--- a/lib/graphql/relay/base_connection.rb
+++ b/lib/graphql/relay/base_connection.rb
@@ -94,7 +94,7 @@ module GraphQL
 
       # Wrap nodes in {Edge}s so they expose cursors.
       def edges
-        @edges ||= paged_nodes.map { |item| Edge.new(item, self) }
+        @edges ||= paged_nodes.map { |item| Edge.new(item, cursor_from_node(item)) }
       end
 
       # Support the `pageInfo` field

--- a/lib/graphql/relay/edge.rb
+++ b/lib/graphql/relay/edge.rb
@@ -4,14 +4,10 @@ module GraphQL
     #
     # Wraps an object as a `node`, and exposes a connection-specific `cursor`.
     class Edge < GraphQL::ObjectType
-      attr_reader :node
-      def initialize(node, connection)
+      attr_reader :node, :cursor
+      def initialize(node, cursor)
         @node = node
-        @connection = connection
-      end
-
-      def cursor
-        @cursor ||= @connection.cursor_from_node(node)
+        @cursor = cursor
       end
 
       def self.create_type(wrapped_type)


### PR DESCRIPTION
Seems like we don't need the whole connection passed to edge everytime. Compute the cursor first and pass it to the `Edge`.

Let me know what you think @rmosolgo 