### PR TITLE
Allow node interface to return nil if object is not a node

### DIFF
--- a/lib/graphql/relay/global_node_identification.rb
+++ b/lib/graphql/relay/global_node_identification.rb
@@ -96,6 +96,8 @@ module GraphQL
       def type_from_object(object)
         type_result = @type_from_object_proc.call(object)
         if !type_result.is_a?(GraphQL::BaseType)
+          return nil if type_result.nil?
+
           type_str = "#{type_result} (#{type_result.class.name})"
           raise "type_from_object(#{object}) returned #{type_str}, but it should return a GraphQL type"
         else


### PR DESCRIPTION
I encountered an odd situation, and I'm thinking that this is a bug in graphql-relay. Here's what happened:

I have these types in my GraphQL schema:
```graphql
interface Node {
  id: ID!
}

interface FileInterface {
  # some fields, but not ID
}

type Attachment implements Node, FileInterface {
  id: ID!,
  # fields from FileInterface
}

type VirtualFile implements FileInterface {
  # fields from FileInterface, no ID
}
```

And then I have a field that returns a `FileInterface`. Relay builds a query against this field:
```graphql
fragment on SomeType {
  file { # returns a VirtualFile
    ...F0
    # some other selections
  }
}

fragment F0 on Node {
  id
  __typename
}
```

When this query is executing, it eventually ends up inside of `GraphQL::Query::SerialExecution::SelectionResolution#fragment_type_can_apply?`, to determine whether or not fragment `F0` applies to the object that my `file` field returned. That eventually ends up in the `type_from_object` proc that I gave to `GlobalNodeIdentification`, which returns `nil`, because the object in this case is not a node. That, in turn, raises an error, because `nil` is not a `GraphQL::BaseType`.

I think `fragment_type_can_apply?` is assuming that when `GraphQL::BaseType::HasPossibleTypes#resolve_type` is called with an object, it will return a `nil` value if the object doesn't match any of the possible types. Here, however, the `type_from_object` proc which is being used for the `Node` interface raises an error if you try to return `nil`.