### PR TITLE
feat(EdgeType) support custom edge class & edge type

### DIFF
--- a/lib/graphql/relay.rb
+++ b/lib/graphql/relay.rb
@@ -7,12 +7,14 @@ require 'graphql/relay/define'
 require 'graphql/relay/global_node_identification'
 require 'graphql/relay/page_info'
 require 'graphql/relay/edge'
+require 'graphql/relay/edge_type'
 require 'graphql/relay/base_connection'
 require 'graphql/relay/array_connection'
 require 'graphql/relay/relation_connection'
 require 'graphql/relay/global_id_field'
 require 'graphql/relay/mutation'
 require 'graphql/relay/connection_field'
+require 'graphql/relay/connection_type'
 
 # Accept Relay-specific definitions
 GraphQL::BaseType.accepts_definitions(

--- a/lib/graphql/relay/connection_type.rb
+++ b/lib/graphql/relay/connection_type.rb
@@ -1,0 +1,25 @@
+module GraphQL
+  module Relay
+    module ConnectionType
+      # Create a connection which exposes edges of this type
+      def self.create_type(wrapped_type, edge_type: nil, edge_class: nil, &block)
+        edge_type ||= wrapped_type.edge_type
+        edge_class ||= GraphQL::Relay::Edge
+        connection_type_name = "#{wrapped_type.name}Connection"
+
+        connection_type = ObjectType.define do
+          name(connection_type_name)
+          field :edges, types[edge_type] do
+            resolve -> (obj, args, ctx) {
+              obj.edge_nodes.map { |item| edge_class.new(item, obj) }
+            }
+          end
+          field :pageInfo, PageInfo, property: :page_info
+          block && instance_eval(&block)
+        end
+
+        connection_type
+      end
+    end
+  end
+end

--- a/lib/graphql/relay/edge.rb
+++ b/lib/graphql/relay/edge.rb
@@ -4,22 +4,19 @@ module GraphQL
     #
     # Wraps an object as a `node`, and exposes a connection-specific `cursor`.
     class Edge < GraphQL::ObjectType
-      attr_reader :node
+      attr_reader :node, :parent, :connection
       def initialize(node, connection)
         @node = node
         @connection = connection
+        @parent = parent
       end
 
       def cursor
-        @cursor ||= @connection.cursor_from_node(node)
+        @cursor ||= connection.cursor_from_node(node)
       end
 
-      def self.create_type(wrapped_type)
-        GraphQL::ObjectType.define do
-          name("#{wrapped_type.name}Edge")
-          field :node, wrapped_type
-          field :cursor, !types.String
-        end
+      def parent
+        @parent ||= connection.parent
       end
     end
   end

--- a/lib/graphql/relay/edge_type.rb
+++ b/lib/graphql/relay/edge_type.rb
@@ -1,0 +1,14 @@
+module GraphQL
+  module Relay
+    module EdgeType
+      def self.create_type(wrapped_type, name: nil, &block)
+        GraphQL::ObjectType.define do
+          name("#{wrapped_type.name}Edge")
+          field :node, wrapped_type
+          field :cursor, !types.String
+          block && instance_eval(&block)
+        end
+      end
+    end
+  end
+end

--- a/lib/graphql/relay/monkey_patches/base_type.rb
+++ b/lib/graphql/relay/monkey_patches/base_type.rb
@@ -1,16 +1,21 @@
 class GraphQL::BaseType
+  # Get the default connection type for this object type
   def connection_type
     @connection_type ||= define_connection
   end
 
-  def edge_type
-    @edge_type ||= GraphQL::Relay::Edge.create_type(self)
+  # Define a custom connection type for this object type
+  def define_connection(**kwargs, &block)
+    GraphQL::Relay::ConnectionType.create_type(self, **kwargs, &block)
   end
 
-  def define_connection(&block)
-    if !@connection_type.nil?
-      raise("#{name}'s connection type was already defined, can't redefine it!")
-    end
-    @connection_type = GraphQL::Relay::BaseConnection.create_type(self, &block)
+  # Get the default edge type for this object type
+  def edge_type
+    @edge_type ||= define_edge
+  end
+
+  # Define a custom edge type for this object type
+  def define_edge(**kwargs, &block)
+    GraphQL::Relay::EdgeType.create_type(self, **kwargs, &block)
   end
 end

--- a/spec/graphql/relay/connection_type_spec.rb
+++ b/spec/graphql/relay/connection_type_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+
+describe GraphQL::Relay::ConnectionType do
+  describe ".create_type" do
+    describe "connections with custom Edge classes / EdgeTypes" do
+      let(:query_string) {%|
+        {
+          rebels {
+            basesWithCustomEdge {
+              totalCountTimes100
+              edges {
+                upcasedName
+                edgeClassName
+                node {
+                  name
+                }
+              }
+            }
+          }
+        }
+      |}
+
+      it "uses the custom edge and custom connection" do
+        result = query(query_string)
+        bases = result["data"]["rebels"]["basesWithCustomEdge"]
+        assert_equal 200, bases["totalCountTimes100"]
+        assert_equal ["YAVIN", "ECHO BASE"] , bases["edges"].map { |e| e["upcasedName"] }
+        assert_equal ["Yavin", "Echo Base"] , bases["edges"].map { |e| e["node"]["name"] }
+        assert_equal ["CustomBaseEdge", "CustomBaseEdge"] , bases["edges"].map { |e| e["edgeClassName"] }
+      end
+    end
+  end
+end

--- a/spec/graphql/relay/relation_connection_spec.rb
+++ b/spec/graphql/relay/relation_connection_spec.rb
@@ -20,7 +20,7 @@ describe GraphQL::Relay::RelationConnection do
         }
       }
 
-      fragment basesConnection on BaseConnection {
+      fragment basesConnection on BasesConnectionWithTotalCount {
         totalCount,
         edges {
           cursor
@@ -160,10 +160,17 @@ describe GraphQL::Relay::RelationConnection do
       query getBases {
         empire {
           basesByName(first: 30) { ... basesFields }
-          bases(first: 30) { ... basesFields }
+          bases(first: 30) { ... basesFields2 }
         }
       }
       fragment basesFields on BaseConnection {
+        edges {
+          node {
+            name
+          }
+        }
+      }
+      fragment basesFields2 on BasesConnectionWithTotalCount {
         edges {
           node {
             name
@@ -179,7 +186,6 @@ describe GraphQL::Relay::RelationConnection do
 
     it "applies the default value" do
       result = query(query_string)
-
       bases_by_id   = ["Death Star", "Shield Generator", "Headquarters"]
       bases_by_name = ["Death Star", "Headquarters", "Shield Generator"]
 
@@ -208,7 +214,7 @@ describe GraphQL::Relay::RelationConnection do
           }
         }
 
-        fragment basesConnection on BaseConnection {
+        fragment basesConnection on BasesConnectionWithTotalCount {
           totalCount,
           edges {
             cursor

--- a/spec/support/star_wars_data.rb
+++ b/spec/support/star_wars_data.rb
@@ -10,9 +10,9 @@ names = [
   'Executor',
 ]
 
-## Set up "Bases" in ActiveRecord
 # ActiveRecord::Base.logger = Logger.new(STDOUT)
 `rm -f ./_test_.db`
+# Set up "Bases" in ActiveRecord
 ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: "./_test_.db")
 
 ActiveRecord::Schema.define do


### PR DESCRIPTION
Edge-specific fields _are_ permitted by the Relay spec: 

> Edge types must have fields named node and cursor. They may have additional fields related to the edge, as the schema designer sees fit.

https://facebook.github.io/relay/graphql/connections.htm#sec-Edge-Types.Fields

This adds support in `graphql-relay`.

## Breaking Change 

Previously, calling `define_connection` would cache the Connection type as a property of the ObjectType. It would later be returned by `MyObjType.connection_type`: 

```ruby 
CommentType.define_connection do 
  field :totalCount 
end 

# .... 

PostType = GraphQL::ObjectType.define do 
  # Previously, this _would_ include the customization from above ^^ 
  connection :comments, CommentType.connection_type 
end 
```

Now, `define_connection` _returns_ a connection type, but does not cache it for later use. So, to adapt the above example, you must capture the return value and use it later. Also, you should provide a new `name` so that the _custom_ connection doesn't conflict with the _default_ connection: 

```ruby 
CommentWithCountType = CommentType.define_connection do 
  # Avoid conflict with default connection: 
  name "CommentWithCountConnection" 
  field :totalCount 
end 

# .... 

PostType = GraphQL::ObjectType.define do 
  # Now, you must use the returned type here:
  connection :comments, CommentWithCountType
end 
```

How bad is this breaking change? If need be, we _could_ add `.define_default_connection` which preserves the previous behavior.


