### PR TITLE
refactor(NodeIdentification) accept the config at schema-level, don't cache a global instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ Global ids (or UUIDs) provide refetching & global identification for Relay.
 
 #### UUID Lookup
 
-Use `GraphQL::Relay::GlobalNodeIdentification` helper by defining `object_from_id(global_id, ctx)` & `type_from_object(object)`. The resulting `NodeIdentification` object is in your schema _and_ internally by `GraphQL::Relay`.
+Use `GraphQL::Relay::GlobalNodeIdentification` helper by defining `object_from_id(global_id, ctx)` & `type_from_object(object)`. Then, assign the result to `Schema#node_identification` so that it can be used for query execution.
+
+For example, define a node identification helper:
 
 
 ```ruby
@@ -57,6 +59,14 @@ NodeIdentification = GraphQL::Relay::GlobalNodeIdentification.define do
     end
   end
 end
+```
+
+Then assign it to the schema:
+
+```ruby
+MySchema = GraphQL::Schema.new(...)
+# Assign your node identification helper:
+MySchema.node_identification = NodeIdentification
 ```
 
 #### UUID fields
@@ -110,6 +120,10 @@ NodeIdentification = GraphQL::Relay::GlobalNodeIdentification.define do
     type_name, id
   }
 end
+
+# ...
+
+MySchema.node_identification = NodeIdentification
 ```
 
 `graphql-relay` will use those procs for interacting with global ids.
@@ -449,7 +463,6 @@ https://medium.com/@gauravtiwari/graphql-and-relay-on-rails-first-relay-powered-
 ## Todo
 
 - `GlobalNodeIdentification.to_global_id` should receive the type name and _object_, not `id`. (Or, maintain the "`type_name, id` in, `type_name, id` out" pattern?)
-- Make GlobalId a property of the schema, not a global
 - Reduce duplication in ArrayConnection / RelationConnection
 - Improve API for creating edges (better RANGE_ADD support)
 - If the new edge isn't a member of the connection's objects, raise a nice error

--- a/lib/graphql/relay.rb
+++ b/lib/graphql/relay.rb
@@ -2,6 +2,7 @@ require 'base64'
 require 'graphql'
 # MONKEY PATCHES 😬
 require 'graphql/relay/monkey_patches/base_type'
+require 'graphql/relay/monkey_patches/schema'
 
 require 'graphql/relay/define'
 require 'graphql/relay/global_node_identification'

--- a/lib/graphql/relay/global_id_field.rb
+++ b/lib/graphql/relay/global_id_field.rb
@@ -10,7 +10,7 @@ module GraphQL
         self.arguments = {}
         self.type = !GraphQL::ID_TYPE
         self.resolve = -> (obj, args, ctx) {
-          GraphQL::Relay::GlobalNodeIdentification.to_global_id(type_name, obj.public_send(property))
+          ctx.query.schema.node_identification.to_global_id(type_name, obj.public_send(property))
         }
       end
     end

--- a/lib/graphql/relay/global_node_identification.rb
+++ b/lib/graphql/relay/global_node_identification.rb
@@ -13,18 +13,7 @@ module GraphQL
       attr_accessor :description
 
       class << self
-        attr_accessor :instance, :id_separator
-        def new(*args, &block)
-          @instance = super
-        end
-
-        def from_global_id(id)
-          instance.from_global_id(id)
-        end
-
-        def to_global_id(type_name, id)
-          instance.to_global_id(type_name, id)
-        end
+        attr_accessor :id_separator
       end
 
       self.id_separator = "-"
@@ -55,7 +44,7 @@ module GraphQL
           type(ident.interface)
           argument :id, !types.ID
           resolve -> (obj, args, ctx) {
-            ident.object_from_id(args[:id], ctx)
+            ctx.query.schema.node_identification.object_from_id(args[:id], ctx)
           }
           description ident.description
         end

--- a/lib/graphql/relay/monkey_patches/schema.rb
+++ b/lib/graphql/relay/monkey_patches/schema.rb
@@ -1,0 +1,3 @@
+class GraphQL::Schema
+  attr_accessor :node_identification
+end

--- a/spec/support/star_wars_schema.rb
+++ b/spec/support/star_wars_schema.rb
@@ -7,12 +7,8 @@
 # - an interface for Relay ObjectTypes to implement
 # See global_node_identification.rb for the full API.
 NodeIdentification = GraphQL::Relay::GlobalNodeIdentification.define do
-  object_from_id -> (id, ctx) do
-    # In a normal app, you could call `from_global_id` on your defined object
-    # type_name, id = NodeIdentification.from_global_id(id)
-    #
-    # But to support our testing setup, reach for the global:
-    type_name, id = GraphQL::Relay::GlobalNodeIdentification.from_global_id(id)
+  object_from_id -> (node_id, ctx) do
+    type_name, id = NodeIdentification.from_global_id(node_id)
     STAR_WARS_DATA[type_name][id]
   end
 
@@ -201,3 +197,4 @@ MutationType = GraphQL::ObjectType.define do
 end
 
 StarWarsSchema = GraphQL::Schema.new(query: QueryType, mutation: MutationType)
+StarWarsSchema.node_identification = NodeIdentification


### PR DESCRIPTION
This will be a breaking change but it's gotta happen, the previous arrangement was really subject to all kinds of bugs