### PR TITLE
Pass parent object to connection during execution

### DIFF
--- a/lib/graphql/relay/connection_field.rb
+++ b/lib/graphql/relay/connection_field.rb
@@ -44,7 +44,7 @@ module GraphQL
         -> (obj, args, ctx) {
           items = underlying_resolve.call(obj, args, ctx)
           connection_class = GraphQL::Relay::BaseConnection.connection_for_items(items)
-          connection_class.new(items, args, max_page_size: max_page_size)
+          connection_class.new(items, args, max_page_size: max_page_size, parent: obj)
         }
       end
     end


### PR DESCRIPTION
The ability to create custom edge types was recently added and, with it,
the ability to pass a `parent` object through connections for use in the
connection and custom edge type. However, we forgot to actually _pass_
the parent object in during query execution, so it ended up always being
`nil`. This patch fixes the failing test introduced in the previous
commit.

Signed-off-by: David Celis <me@davidcel.is>