### PR TITLE
Add support for startCursor and endCursor in pageInfo for connections.

### DIFF
--- a/lib/graphql/relay/base_connection.rb
+++ b/lib/graphql/relay/base_connection.rb
@@ -101,6 +101,24 @@ module GraphQL
         !!(last && sliced_nodes.count > last)
       end
 
+      # Used by `pageInfo`
+      def start_cursor
+        if start_node = (respond_to?(:paged_nodes_array, true) ? paged_nodes_array : paged_nodes).first
+          return cursor_from_node(start_node)
+        else
+          return nil
+        end
+      end
+
+      # Used by `pageInfo`
+      def end_cursor
+        if end_node = (respond_to?(:paged_nodes_array, true) ? paged_nodes_array : paged_nodes).last
+          return cursor_from_node(end_node)
+        else
+          return nil
+        end
+      end
+
       # An opaque operation which returns a connection-specific cursor.
       def cursor_from_node(object)
         raise NotImplementedError, "must return a cursor for this object/connection pair"

--- a/lib/graphql/relay/connection_type.rb
+++ b/lib/graphql/relay/connection_type.rb
@@ -14,7 +14,7 @@ module GraphQL
               obj.edge_nodes.map { |item| edge_class.new(item, obj) }
             }
           end
-          field :pageInfo, PageInfo, property: :page_info
+          field :pageInfo, !PageInfo, property: :page_info
           block && instance_eval(&block)
         end
 

--- a/lib/graphql/relay/page_info.rb
+++ b/lib/graphql/relay/page_info.rb
@@ -6,6 +6,8 @@ module GraphQL
       description("Metadata about a connection")
       field :hasNextPage, !types.Boolean, "Indicates if there are more pages to fetch", property: :has_next_page
       field :hasPreviousPage, !types.Boolean, "Indicates if there are any pages prior to the current page", property: :has_previous_page
+      field :startCursor, types.String, "When paginating backwards, the cursor to continue", property: :start_cursor
+      field :endCursor, types.String, "When paginating forwards, the cursor to continue", property: :end_cursor
     end
   end
 end

--- a/spec/graphql/relay/array_connection_spec.rb
+++ b/spec/graphql/relay/array_connection_spec.rb
@@ -22,6 +22,9 @@ describe GraphQL::Relay::ArrayConnection do
             }
             pageInfo {
               hasNextPage
+              hasPreviousPage
+              startCursor
+              endCursor
             }
           }
         }
@@ -33,6 +36,9 @@ describe GraphQL::Relay::ArrayConnection do
       number_of_ships = get_names(result).length
       assert_equal(2, number_of_ships)
       assert_equal(true, result["data"]["rebels"]["ships"]["pageInfo"]["hasNextPage"])
+      assert_equal(false, result["data"]["rebels"]["ships"]["pageInfo"]["hasPreviousPage"])
+      assert_equal("MQ==", result["data"]["rebels"]["ships"]["pageInfo"]["startCursor"])
+      assert_equal("Mg==", result["data"]["rebels"]["ships"]["pageInfo"]["endCursor"])
 
       result = query(query_string, "first" => 3)
       number_of_ships = get_names(result).length
@@ -42,9 +48,15 @@ describe GraphQL::Relay::ArrayConnection do
     it 'provides pageInfo' do
       result = query(query_string, "first" => 2)
       assert_equal(true, result["data"]["rebels"]["ships"]["pageInfo"]["hasNextPage"])
+      assert_equal(false, result["data"]["rebels"]["ships"]["pageInfo"]["hasPreviousPage"])
+      assert_equal("MQ==", result["data"]["rebels"]["ships"]["pageInfo"]["startCursor"])
+      assert_equal("Mg==", result["data"]["rebels"]["ships"]["pageInfo"]["endCursor"])
 
       result = query(query_string, "first" => 100)
       assert_equal(false, result["data"]["rebels"]["ships"]["pageInfo"]["hasNextPage"])
+      assert_equal(false, result["data"]["rebels"]["ships"]["pageInfo"]["hasPreviousPage"])
+      assert_equal("MQ==", result["data"]["rebels"]["ships"]["pageInfo"]["startCursor"])
+      assert_equal("NQ==", result["data"]["rebels"]["ships"]["pageInfo"]["endCursor"])
     end
 
     it 'slices the result' do
@@ -82,6 +94,9 @@ describe GraphQL::Relay::ArrayConnection do
       result = query(query_string)
 
       assert_equal(false, result["data"]["rebels"]["ships"]["pageInfo"]["hasNextPage"])
+      assert_equal(false, result["data"]["rebels"]["ships"]["pageInfo"]["hasPreviousPage"])
+      assert_equal("MQ==", result["data"]["rebels"]["ships"]["pageInfo"]["startCursor"])
+      assert_equal("NQ==", result["data"]["rebels"]["ships"]["pageInfo"]["endCursor"])
       assert_equal(5, result["data"]["rebels"]["ships"]["edges"].length)
     end
   end

--- a/spec/graphql/relay/page_info_spec.rb
+++ b/spec/graphql/relay/page_info_spec.rb
@@ -5,6 +5,10 @@ describe GraphQL::Relay::PageInfo do
     result["data"]["empire"]["bases"]["pageInfo"]
   end
 
+  def get_first_cursor(result)
+    result["data"]["empire"]["bases"]["edges"].first["cursor"]
+  end
+
   def get_last_cursor(result)
     result["data"]["empire"]["bases"]["edges"].last["cursor"]
   end
@@ -24,6 +28,8 @@ describe GraphQL::Relay::PageInfo do
           pageInfo {
             hasNextPage
             hasPreviousPage
+            startCursor
+            endCursor
           }
         }
       }
@@ -35,28 +41,63 @@ describe GraphQL::Relay::PageInfo do
       result = query(query_string, "first" => 2)
       assert_equal(true, get_page_info(result)["hasNextPage"])
       assert_equal(false, get_page_info(result)["hasPreviousPage"], "hasPreviousPage is false if 'last' is missing")
+      assert_equal("MQ==", get_page_info(result)["startCursor"])
+      assert_equal("Mg==", get_page_info(result)["endCursor"])
 
       last_cursor = get_last_cursor(result)
       result = query(query_string, "first" => 100, "after" => last_cursor)
       assert_equal(false, get_page_info(result)["hasNextPage"])
       assert_equal(false, get_page_info(result)["hasPreviousPage"])
+      assert_equal("Mw==", get_page_info(result)["startCursor"])
+      assert_equal("Mw==", get_page_info(result)["endCursor"])
     end
 
     it "hasPreviousPage if there are more items" do
       result = query(query_string, "last" => 100, "before" => cursor_of_last_base)
       assert_equal(false, get_page_info(result)["hasNextPage"])
       assert_equal(false, get_page_info(result)["hasPreviousPage"])
+      assert_equal("MQ==", get_page_info(result)["startCursor"])
+      assert_equal("Mg==", get_page_info(result)["endCursor"])
 
       result = query(query_string, "last" => 1, "before" => cursor_of_last_base)
       assert_equal(false, get_page_info(result)["hasNextPage"])
       assert_equal(true, get_page_info(result)["hasPreviousPage"])
+      assert_equal("Mg==", get_page_info(result)["startCursor"])
+      assert_equal("Mg==", get_page_info(result)["endCursor"])
     end
-
 
     it "has both if first and last are present" do
       result = query(query_string, "last" => 1, "first" => 1, "before" => cursor_of_last_base)
       assert_equal(true, get_page_info(result)["hasNextPage"])
       assert_equal(true, get_page_info(result)["hasPreviousPage"])
+      assert_equal("Mg==", get_page_info(result)["startCursor"])
+      assert_equal("Mg==", get_page_info(result)["endCursor"])
+    end
+
+    it "startCursor and endCursor are the cursors of the first and last edge" do
+      result = query(query_string, "first" => 2)
+      assert_equal(true, get_page_info(result)["hasNextPage"])
+      assert_equal(false, get_page_info(result)["hasPreviousPage"])
+      assert_equal("MQ==", get_page_info(result)["startCursor"])
+      assert_equal("Mg==", get_page_info(result)["endCursor"])
+      assert_equal("MQ==", get_first_cursor(result))
+      assert_equal("Mg==", get_last_cursor(result))
+
+      result = query(query_string, "first" => 1, "after" => get_page_info(result)["endCursor"])
+      assert_equal(false, get_page_info(result)["hasNextPage"])
+      assert_equal(false, get_page_info(result)["hasPreviousPage"])
+      assert_equal("Mw==", get_page_info(result)["startCursor"])
+      assert_equal("Mw==", get_page_info(result)["endCursor"])
+      assert_equal("Mw==", get_first_cursor(result))
+      assert_equal("Mw==", get_last_cursor(result))
+
+      result = query(query_string, "last" => 1, "before" => get_page_info(result)["endCursor"])
+      assert_equal(false, get_page_info(result)["hasNextPage"])
+      assert_equal(true, get_page_info(result)["hasPreviousPage"])
+      assert_equal("Mg==", get_page_info(result)["startCursor"])
+      assert_equal("Mg==", get_page_info(result)["endCursor"])
+      assert_equal("Mg==", get_first_cursor(result))
+      assert_equal("Mg==", get_last_cursor(result))
     end
   end
 

--- a/spec/graphql/relay/relation_connection_spec.rb
+++ b/spec/graphql/relay/relation_connection_spec.rb
@@ -6,6 +6,14 @@ describe GraphQL::Relay::RelationConnection do
     names = ships.map { |e| e["node"]["name"] }
   end
 
+  def get_page_info(result)
+    result["data"]["empire"]["bases"]["pageInfo"]
+  end
+
+  def get_first_cursor(result)
+    result["data"]["empire"]["bases"]["edges"].first["cursor"]
+  end
+
   def get_last_cursor(result)
     result["data"]["empire"]["bases"]["edges"].last["cursor"]
   end
@@ -30,6 +38,9 @@ describe GraphQL::Relay::RelationConnection do
         },
         pageInfo {
           hasNextPage
+          hasPreviousPage
+          startCursor
+          endCursor
         }
       }
     |}
@@ -37,12 +48,24 @@ describe GraphQL::Relay::RelationConnection do
     it 'limits the result' do
       result = query(query_string, "first" => 2)
       assert_equal(2, get_names(result).length)
+      assert_equal(true, get_page_info(result)["hasNextPage"])
+      assert_equal(false, get_page_info(result)["hasPreviousPage"])
+      assert_equal("MQ==", get_page_info(result)["startCursor"])
+      assert_equal("Mg==", get_page_info(result)["endCursor"])
+      assert_equal("MQ==", get_first_cursor(result))
+      assert_equal("Mg==", get_last_cursor(result))
 
       result = query(query_string, "first" => 3)
       assert_equal(3, get_names(result).length)
+      assert_equal(false, get_page_info(result)["hasNextPage"])
+      assert_equal(false, get_page_info(result)["hasPreviousPage"])
+      assert_equal("MQ==", get_page_info(result)["startCursor"])
+      assert_equal("Mw==", get_page_info(result)["endCursor"])
+      assert_equal("MQ==", get_first_cursor(result))
+      assert_equal("Mw==", get_last_cursor(result))
     end
 
-    it 'provides custom fileds on the connection type' do
+    it 'provides custom fields on the connection type' do
       result = query(query_string, "first" => 2)
       assert_equal(
         Base.where(faction_id: 2).count,
@@ -200,6 +223,14 @@ describe GraphQL::Relay::RelationConnection do
       names = ships.map { |e| e["node"]["name"] }
     end
 
+    def get_page_info(result)
+      result["data"]["empire"]["basesAsSequelDataset"]["pageInfo"]
+    end
+
+    def get_first_cursor(result)
+      result["data"]["empire"]["basesAsSequelDataset"]["edges"].first["cursor"]
+    end
+
     def get_last_cursor(result)
       result["data"]["empire"]["basesAsSequelDataset"]["edges"].last["cursor"]
     end
@@ -224,6 +255,9 @@ describe GraphQL::Relay::RelationConnection do
           },
           pageInfo {
             hasNextPage
+            hasPreviousPage
+            startCursor
+            endCursor
           }
         }
       |}
@@ -231,12 +265,24 @@ describe GraphQL::Relay::RelationConnection do
       it 'limits the result' do
         result = query(query_string, "first" => 2)
         assert_equal(2, get_names(result).length)
+        assert_equal(true, get_page_info(result)["hasNextPage"])
+        assert_equal(false, get_page_info(result)["hasPreviousPage"])
+        assert_equal("MQ==", get_page_info(result)["startCursor"])
+        assert_equal("Mg==", get_page_info(result)["endCursor"])
+        assert_equal("MQ==", get_first_cursor(result))
+        assert_equal("Mg==", get_last_cursor(result))
 
         result = query(query_string, "first" => 3)
         assert_equal(3, get_names(result).length)
+        assert_equal(false, get_page_info(result)["hasNextPage"])
+        assert_equal(false, get_page_info(result)["hasPreviousPage"])
+        assert_equal("MQ==", get_page_info(result)["startCursor"])
+        assert_equal("Mw==", get_page_info(result)["endCursor"])
+        assert_equal("MQ==", get_first_cursor(result))
+        assert_equal("Mw==", get_last_cursor(result))
       end
 
-      it 'provides custom fileds on the connection type' do
+      it 'provides custom fields on the connection type' do
         result = query(query_string, "first" => 2)
         assert_equal(
           Base.where(faction_id: 2).count,


### PR DESCRIPTION
This pull request has 3 main changes:

1. Change `pageInfo` to be non‐null (see [section 2.1.2 of Relay Cursor Connections Specification](https://facebook.github.io/relay/graphql/connections.htm#sec-Connection-Types.Fields.PageInfo)).
2. Add support for `startCursor` and `endCursor` as mentioned in the [GraphQL Relay Specification](https://facebook.github.io/relay/docs/graphql-relay-specification.html) (but not in the [Relay Cursor Connections Specification](https://facebook.github.io/relay/graphql/connections.htm) for some reason).
3. Tests added to check for correct `startCursor` and `endCursor` values on `pageInfo`.

I also fixed the spelling of `fileds` to `fields` on a couple of unrelated tests that I noticed while running the tests locally.

Thanks for the excellent library!