### PR TITLE
Be more careful about assuming the existence of Sequel/ActiveRecord classes.

### DIFF
--- a/lib/graphql/relay/relation_connection.rb
+++ b/lib/graphql/relay/relation_connection.rb
@@ -94,10 +94,10 @@ module GraphQL
     end
 
 
-    if defined?(ActiveRecord)
+    if defined?(ActiveRecord::Relation)
       BaseConnection.register_connection_implementation(ActiveRecord::Relation, RelationConnection)
     end
-    if defined?(Sequel)
+    if defined?(Sequel::Dataset)
       BaseConnection.register_connection_implementation(Sequel::Dataset, RelationConnection)
     end
   end


### PR DESCRIPTION
Minor issue. I was updating some gems in an app of mine and started getting a `lib/graphql/relay/relation_connection.rb:101:in '<module:Relay>': uninitialized constant Sequel::Dataset (NameError)`. Turns out, due to the ordering of some lines in my Gemfile, graphql-relay was being required after a Sequel extension (which declared itself in a namespace under the Sequel module) but before Sequel itself. So the Sequel module was defined, but Sequel::Dataset itself was not. It made sense to be that if this code wants to do something dependent on whether Sequel::Dataset is available, it should be checking for that class rather than the Sequel module.

Did the same for ActiveRecord because the same issue seemed possible there.